### PR TITLE
Fix build for armv7-unknown-linux-musleabihf (RPi), bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faccess"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Thomas Hurst <tom@hur.st>"]
 edition = "2018"
 description = "Simple file accessibility checks"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ mod imp {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
-    use libc::{c_int, faccessat, AT_FDCWD, F_OK, R_OK, W_OK, X_OK};
+    use libc::{c_int, c_char, faccessat, AT_FDCWD, F_OK, R_OK, W_OK, X_OK};
 
     // Not provided on Android
     #[cfg(not(target_os = "android"))]
@@ -92,7 +92,7 @@ mod imp {
     fn eaccess(p: &Path, mode: c_int) -> io::Result<()> {
         let path = CString::new(p.as_os_str().as_bytes())?;
         unsafe {
-            if faccessat(AT_FDCWD, path.as_ptr() as *const i8, mode, AT_EACCESS) == 0 {
+            if faccessat(AT_FDCWD, path.as_ptr() as *const c_char, mode, AT_EACCESS) == 0 {
                 Ok(())
             } else {
                 Err(io::Error::last_os_error())


### PR DESCRIPTION
Fixes this error:

```
   Compiling faccess v0.2.3
error[E0308]: mismatched types
  --> /home/flowbox/.cargo/registry/src/github.com-1ecc6299db9ec823/faccess-0.2.3/src/lib.rs:95:36
   |
95 |             if faccessat(AT_FDCWD, path.as_ptr() as *const i8, mode, AT_EACCESS) == 0 {
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*const i8`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `faccess`.

To learn more, run the command again with --verbose.
```